### PR TITLE
Add unsubscribe and disconnect methods on the ActionCable object

### DIFF
--- a/src/actioncable.js
+++ b/src/actioncable.js
@@ -43,8 +43,10 @@ class ActionCable {
   }
 
   unsubscribe (subscription_name) {
-    this.subscriptions[subscription_name].unsubscribe();
-    delete this.subscriptions[subscription_name];
+    if (this.subscriptions.subscription_name) {
+      this.subscriptions[subscription_name].unsubscribe();
+      delete this.subscriptions[subscription_name];
+    }
   }
 
   disconnect () {

--- a/src/actioncable.js
+++ b/src/actioncable.js
@@ -42,6 +42,18 @@ class ActionCable {
     return this.subscriptions[name];
   }
 
+  unsubscribe (subscription_name) {
+    this.subscriptions[subscription_name].unsubscribe();
+    delete this.subscriptions[subscription_name];
+  }
+
+  disconnect () {
+    for (const subscription_name in this.subscriptions) {
+      this.unsubscribe(subscription_name);
+    }
+    this.connection.close();
+  }
+
   // PRIVATE
 
   _connect() {


### PR DESCRIPTION
Adds methods on the `ActionCable` object to `unsubscribe` from channels on the subscriptions object, and to `disconnect` from the websocket entirely.